### PR TITLE
Adding information about the active Repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,27 +1,13 @@
-![logo](https://github.com/flosscoach/flosscoach/raw/master/app/assets/images/flosscoach-logo.png) 
-# FLOSSCoach
-We are a community aimed to help newcomers get into
-*Free/Libre Open Source Software* (FLOSS). 
+!![logo](https://gitlab.com/flosscoach/flosscoach/raw/master/app/assets/images/flosscoach-logo.png) 
+# FLOSScoach
+We are a community aimed to help newcomers get into *Free/Libre Open Source Software* (FLOSS). FLOSScoach helps by providing a way to organize the information, 
+benefiting newcomers to avoid or overcome the most common barriers they face according to the research literature. The tool enables the inclusion of information
+about existing projects in a standardized way, making it easier for newcomer to get used to the contribution flow.
 
-## How to use?
-If you want to use [FLOSScoach](http://www.flosscoach.com) create an account and join our community! Contact us for help!
-
-## Build status [**Migrate do GitHub]
-![Gitlab pipeline status](https://img.shields.io/gitlab/pipeline/flosscoach/flosscoach.svg) 
-
-## Features
 FLOSSCoach portal has individual project pages, foruns and messages where you can exchange relevant information about OSS with newcomers so they can start contributing
-## Technologies
-FLOSScoach is build using:
 
-- [Ruby on Rails](https://github.com/rails/rails)
-- [PostgreSQL](https://www.postgresql.org/)
-- [GitLab CI](https://about.gitlab.com/product/continuous-integration/) -- **Need to be migrated to GitHub CI
+You can use FLOSScoach by accessing [www.flosscoach.com](http://www.flosscoach.com): create an account and join our community! Contact us for help!
 
-## Code style
-We recommend using [Rails-Style-Guide](https://github.com/rubocop-hq/rails-style-guide) as a coding style
 
-## Contribute
-Want to contribute and not sure how to start? Here's our documentation for [contributions](https://github.com/flosscoach/flosscoach/blob/master/contribute.md).
-
-We are happy to welcome new contributors. 
+# IMPORTANT:
+***This is just a mirror*** The active repositories is hosted by GitLab: https://gitlab.com/flosscoach/flosscoach

--- a/README.md
+++ b/README.md
@@ -11,3 +11,5 @@ You can use FLOSScoach by accessing [www.flosscoach.com](http://www.flosscoach.c
 
 # IMPORTANT:
 ***This is just a mirror*** The active repositories is hosted by GitLab: https://gitlab.com/flosscoach/flosscoach
+
+Testing plugin


### PR DESCRIPTION
FLOSScoach code is not maintained here, it is maintained in GitLab. Changed the README to point to GitLab